### PR TITLE
fixed links of file-protocol for multiline-links

### DIFF
--- a/BBCodePlus/BBCodePlus.php
+++ b/BBCodePlus/BBCodePlus.php
@@ -232,7 +232,7 @@
 			
 			# if there are any expressed links, images convert them to bbcode.
 			$p_string = preg_replace( "/^((http|https|ftp|file):\/\/[a-z0-9;\/\?:@=\&\$\-_\.\+!*'\(\),~%#\|]+)/i", "[url]$1[/url]", $p_string );
-			$p_string = preg_replace( "/([^='\"(\[url\]|\[img\])])((http|https|ftp|file):\/\/[\/a-z0-9;\/\?:@=\&\$\-_\.\+!*'\(\),~%#]+)/i", "$1[url]$2[/url]", $p_string );
+			$p_string = preg_replace( "/([^='\"(\[url\]|\[img\])])((http|https|ftp|file):\/\/[\/a-z0-9;\/\?:@=\&\$\-_\.\+!*'\(\),~%#\|]+)/i", "$1[url]$2[/url]", $p_string );
 			
 			$t_search[] = "/\[img\]((http|https|ftp):\/\/[a-z0-9;\/\?:@=\&\$\-_\.\+!*'\(\),~%# ]+?)\[\/img\]/is";
 			$t_search[] = "/\[img\]([.]*[a-z0-9;\/\?:@=\&\$\-_\.\+!*'\(\),~%# ]+?)\[\/img\]/is";


### PR DESCRIPTION
links weren't working when there was text ahead
