### PR TITLE
Fixed display of quotes when quotee's name contains unicode characters

### DIFF
--- a/BBCodePlus/BBCodePlus.php
+++ b/BBCodePlus/BBCodePlus.php
@@ -22,7 +22,7 @@
          $this->name        = plugin_lang_get( 'title' );
          $this->description = plugin_lang_get( 'description' );
          $this->page        = 'config';
-         $this->version     = '2.1.10';
+         $this->version     = '2.1.11';
 
          $this->requires['MantisCore'] = '2.0.0';
          # this plugin can coexist with MantisCoreFormatting.

--- a/BBCodePlus/BBCodePlus.php
+++ b/BBCodePlus/BBCodePlus.php
@@ -22,7 +22,7 @@
          $this->name        = plugin_lang_get( 'title' );
          $this->description = plugin_lang_get( 'description' );
          $this->page        = 'config';
-         $this->version     = '2.1.11';
+         $this->version     = '2.1.12';
 
          $this->requires['MantisCore'] = '2.0.0';
          # this plugin can coexist with MantisCoreFormatting.

--- a/BBCodePlus/BBCodePlus.php
+++ b/BBCodePlus/BBCodePlus.php
@@ -278,7 +278,7 @@
          $this->t_bbCode->addParser('code-lang-ln', '/\[code=(\w*)\ start=([0-9]+)\](.*?)\[\/code\]/s',
                                     '<pre class="bbcodeplus pre line-numbers" data-start="$2"><code class="bbcodeplus code language-$1">$3</code></pre>', '$3');
          $this->t_bbCode->addParser('quote', '/\[quote\](.*?)\[\/quote\]/s', '<blockquote class="bbcodeplus blockquote">$1</blockquote>', '$1');
-         $this->t_bbCode->addParser('named-quote', '/\[quote=([\s\w]*)\](.*?)\[\/quote\]/s',
+         $this->t_bbCode->addParser('named-quote', '/\[quote=([\s\w,\']*)\](.*?)\[\/quote\]/su',
                                     '<blockquote class="bbcodeplus blockquote"><p class="mb-0">$2</p><footer class="bbcodeblus blockquote-footer"><cite title="$1">$1</cite></footer></blockquote>',
                                     '$1 wrote: $2');
       }

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ If you would like to contribute to BBCode plus, please [read this guide first](h
 
 ## Change Log
 
+### 2.1.12
+
+- Fixed display of quotes when quotee's name contains unicode characters, commas or single quotes [@FSD-Christian-ISS](https://github.com/FSD-Christian-ISS)
+
 ### 2.1.11
 
 - Fixed issue with additional protocols in link insertion.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ If you would like to contribute to BBCode plus, please [read this guide first](h
 
 ## Change Log
 
+### 2.1.11
+
+- Fixed display of quotes when quotee's name contains unicode characters, commas or single quotes [@FSD-Christian-ISS](https://github.com/FSD-Christian-ISS)
+
 ### 2.1.10
 
 - Fixed rendering issue of code blocks when language parameter was left empty


### PR DESCRIPTION
Fixed display of quotes when quotee's name contains unicode characters, commas or single quotes
changes:
- added \u modifier
- added comma and single quote in character list